### PR TITLE
Removed DAWOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ All PR's are now being entertained ,Please star this repo in order to get furthe
 | [Kharagpur Winter Of Code](https://kwoc.kossiitkgp.org/) | Swag rewards|  [timeline](https://kwoc.kossiitkgp.org/#tline)|
 | [OpenCode IIITA](https://opencodeiiita.github.io/) | Swag rewards|  |
 | [FOSSEE Summer Fellowship](https://fossee.in/) | No |   |
-| [DAWOC](https://dawoc.herokuapp.com/) | No  |    |
 | [Winter of Code by NSEC](https://winterofcode.com/) | Swag rewards|  |
-| [Semester Long Projects](https://slop.dscdaiict.in/) (SLoP by DAIICT) | Prizes, swag rewards and internship opportunities for winners|  |
+| [Semester Long Projects](https://slop.dscdaiict.in/) (SLoP by DA-IICT) | Prizes, swag rewards and internship opportunities for winners|  |
 | [Sanscript Autumn of Open Source](https://aos.sanscript.tech/) | Winner Certificate + Badge + surprise gifts|  |


### PR DESCRIPTION
This [website](https://github.com/ossdaiict/DAWoC-legacy-website) clarifies that DAWoC is no longer running. It has been possibly replaced by SLoP, which was added in #15 