### PR TITLE
Add Nasqueron internship program

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ So, what are you waiting for? Don't miss out on this opportunity to connect, lea
 | [Microsoft Learn Student Ambassador Program](https://studentambassadors.microsoft.com/)  | NO | | | |N/A
 | [Microsoft Reinforcement Learning Open Source Fest](https://www.microsoft.com/en-us/research/academic-program/rl-open-source-fest/) | Yes | [timeline](https://www.microsoft.com/en-us/research/academic-program/rl-open-source-fest/timeline/) | May 9, 2022 <br/> Sep 12, 2022| Aug 15, 2022 <br/> Dec 2, 2022|N/A
 | [Devtron](https://devtron.ai/careers.html) | Yes |  | | | N/A
+| [Nasqueron DevOps & Dev Open Source Program](http://join.nasqueron.org/) | No | | Whole Year | | N/A
 
 * *Interns must be currently enrolled or employed at a U.S. university or other research institution and must currently reside in, and be eligible to work in, the United States.<br>
 * ** OSoC is only open to Belgian students.


### PR DESCRIPTION
Nasqueron launched an internship program
described at https://join.nasqueron.org/.

The specificity is it also allows devops, SRE and infrastructure
open source contributions, in addition to development ones.

No stipend is currently offered, and applications are accepted
through the whole year for 2023 program kickstart.