### PR TITLE
Add Nasqueron 2025-2026 internship program

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Don't miss out on this transformative experience! [Join 30 Days Coding now](http
 | [Free Software Foundation Internship](https://www.fsf.org/volunteer/internships) | No | Multiple batches | Open to all | Free software movement |
 | [Python Software Foundation Fellowship Program](https://www.python.org/psf/grants/) | Grants | Rolling | Open to all | Python ecosystem |
 | [The Processing Foundation Fellowships](https://processingfoundation.org/fellowships) | Stipend | Annual | Open to all | Art, technology, education |
+| [Nasqueron DevOps & Dev Open Source Program](http://join.nasqueron.org/) | No | Annual | Open to all | DevOps, open source projects |
 
 ## 🚀 Coding Bootcamps and Intensive Programs
 


### PR DESCRIPTION
Nasqueron internship program is described at https://join.nasqueron.org/.
It has been renewed for October 2025 - June 2026.

The specificity is it also allows DevOps, SRE and infrastructure open source contributions, in addition to development ones.

A new focus on DevSecOps is also added this year.